### PR TITLE
fix/stop

### DIFF
--- a/ovos_media_plugin_spotify/audio.py
+++ b/ovos_media_plugin_spotify/audio.py
@@ -70,8 +70,9 @@ class SpotifyAudioService(AudioBackend):
 
     def stop(self):
         # there is no hard stop method
-        self.spotify.pause(self.device_name)
-        self.on_track_end()
+        if not self._paused:
+            self.spotify.pause(self.device_name)
+            self.on_track_end()
 
     def pause(self):
         if self.spotify.is_playing(self.device_name):


### PR DESCRIPTION
don't attempt to stop spotify players unless they are active

avoids error logs of the sort
```
2024-07-17 16:57:23.683 - audio - ovos_audio.audio:shutdown:567 - INFO - shutting down OpenVoiceOS-TV
2024-07-17 16:57:25.053 - audio - ovos_audio.audio:shutdown:570 - ERROR - shutdown of OpenVoiceOS-TV failed: SpotifyException(404, -1, 'https://api.spotify.com/v1/me/player/pause?device_id=OpenVoiceOS-TV:\n Device not found')
2024-07-17 16:57:25.053 - audio - ovos_audio.audio:shutdown:567 - INFO - shutting down spotify-OpenVoiceOS-TV
HTTP Error for PUT to https://api.spotify.com/v1/me/player/pause?device_id=OpenVoiceOS-TV with Params: {} returned 404 due to Device not found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by preventing redundant pausing of Spotify playback when it is already paused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->