### PR TITLE
feat:spotifyd_integration

### DIFF
--- a/ovos_media_plugin_spotify/__init__.py
+++ b/ovos_media_plugin_spotify/__init__.py
@@ -1,10 +1,10 @@
 import time
 
-from ovos_bus_client.message import Message
 from ovos_plugin_manager.templates.media import AudioPlayerBackend
 from ovos_utils.log import LOG
 
 from ovos_media_plugin_spotify.spotify_client import SpotifyClient
+from ovos_media_plugin_spotify.spotifyd import SpotifydHooks
 
 
 class SpotifyOCPAudioService(AudioPlayerBackend):
@@ -17,85 +17,12 @@ class SpotifyOCPAudioService(AudioPlayerBackend):
         self.spotify = SpotifyClient()
         self._paused = False
         self._last_sync_ts = 0
-        self._track_len = 0
-        self._track_pos = 0
         self.device_name = self.config.get("identifier")  # device name in spotify
+        self.hooks = SpotifydHooks(bus=self.bus,
+                                   track_start_callback=self.on_track_start,
+                                   track_end_callback=self.on_track_end,
+                                   track_error_callback=self.on_track_error)
 
-        self.bus.on("spotifyd.start", self.on_spotify_start)
-        self.bus.on("spotifyd.play", self.on_spotify_play)
-        self.bus.on("spotifyd.pause", self.on_spotify_pause)
-        self.bus.on("spotifyd.stop", self.on_spotify_stop)
-        self.bus.on("spotifyd.load", self.on_spotify_load)
-        self.bus.on("spotifyd.end_of_track", self.on_spotify_end)
-        self.bus.on("spotifyd.change", self.on_spotify_change)
-        self.bus.on("spotifyd.preloading", self.on_spotify_preloading)
-
-    ##################
-    # spotifyd hooks
-    def on_spotify_start(self, message: Message):
-        self._last_sync_ts = time.time()
-        self._now_playing = "spotify:track:" + message.data["track_id"]
-        self._track_pos = message.data["position"]  # milliseconds
-        self.bus.emit(message.forward("ovos.common_play.media.state",
-                                      {"state": 2}))  # loading media
-
-    def on_spotify_play(self, message: Message):
-        self._last_sync_ts = time.time()
-        self._now_playing = "spotify:track:" + message.data["track_id"]
-        self._track_len = message.data["duration"]  # milliseconds
-        self._track_pos = message.data["position"]  # milliseconds
-
-        self.on_track_start()
-        self.bus.emit(message.forward("ovos.common_play.player.state",
-                                      {"state": 1}))  # playing
-        self.bus.emit(message.forward("ovos.common_play.media.state",
-                                      {"state": 6}))  # buffered media
-
-    def on_spotify_stop(self, message: Message):
-        self._now_playing = None
-        self._track_len = 0
-        self._track_pos = 0
-        self._last_sync_ts = 0
-        self.bus.emit(message.forward("ovos.common_play.media.state",
-                                      {"state": 1}))  # no media
-        self.bus.emit(message.forward("ovos.common_play.player.state",
-                                      {"state": 0}))  # stopped
-
-    def on_spotify_pause(self, message: Message):
-        self._now_playing = "spotify:track:" + message.data["track_id"]
-        self._track_len = message.data["duration"]  # milliseconds
-        self._track_pos = message.data["position"]  # milliseconds
-        self._last_sync_ts = 0
-        self.bus.emit(message.forward("ovos.common_play.player.state",
-                                      {"state": 2}))  # paused
-
-    def on_spotify_load(self, message: Message):
-        self._last_sync_ts = time.time()
-        self._track_pos = message.data["position"]  # milliseconds
-        self._now_playing = "spotify:track:" + message.data["track_id"]
-
-    def on_spotify_preloading(self, message: Message):
-        # when track is about to end we get info about next song
-        # we could show a "coming up next" popup
-        pass
-
-    def on_spotify_end(self, message: Message):
-        self._track_pos = self._track_len
-        self.on_track_end()
-        self.bus.emit(message.forward("ovos.common_play.player.state",
-                                      {"state": 2}))  # paused
-        self.bus.emit(message.forward("ovos.common_play.media.state",
-                                      {"state": 7}))  # end of media
-
-    def on_spotify_change(self, message: Message):
-        self._now_playing = "spotify:track:" + message.data["track_id"]
-        self._last_sync_ts = time.time()
-        self.bus.emit(message.forward("ovos.common_play.player.state",
-                                      {"state": 2}))  # paused
-        self.bus.emit(message.forward("ovos.common_play.media.state",
-                                      {"state": 2}))  # loading media
-
-    #################
     @property
     def device(self):
         for d in self.spotify.devices:
@@ -110,24 +37,30 @@ class SpotifyOCPAudioService(AudioPlayerBackend):
             return []
         return ['spotify']
 
-    def on_track_start(self):
+    def on_track_start(self, uri: str = ""):
+        self._now_playing = uri or self._now_playing
         self._last_sync_ts = time.time()
         # Indicate to audio service which track is being played
         if self._track_start_callback:
             self._track_start_callback(self._now_playing)
 
-    def on_track_end(self):
+    def on_track_end(self, uri: str = ""):
+        if not uri:
+            self.hooks.reset_metadata()
         self._paused = False
         self._last_sync_ts = 0
         if self._track_start_callback:
             self._track_start_callback(None)
 
-    def on_track_error(self):
+    def on_track_error(self, uri: str = ""):
+        if not uri:
+            self.hooks.reset_metadata()
         self._paused = False
         self._last_sync_ts = 0
         self.ocp_error()
 
     def play(self):
+        self.hooks.preload_uri(self._now_playing)
         self.on_track_start()
         try:
             self.spotify.play([self._now_playing],
@@ -176,18 +109,13 @@ class SpotifyOCPAudioService(AudioPlayerBackend):
         """
         getting the duration of the audio in milliseconds
         """
-        return self._track_len or self.get_track_position()
+        return self.hooks.get_track_length()
 
     def get_track_position(self) -> int:
         """
         get current position in milliseconds
         """
-        pos = self._track_pos or 0
-        if self._last_sync_ts:  # add the elapsed time since last update of self._track_pos
-            pos += (time.time() - self._last_sync_ts) * 1000
-        if not self._track_len:
-            self._track_len = pos
-        return min(pos, self._track_len)
+        return self.hooks.get_track_position()
 
     def set_track_position(self, milliseconds):
         """

--- a/ovos_media_plugin_spotify/__init__.py
+++ b/ovos_media_plugin_spotify/__init__.py
@@ -1,5 +1,6 @@
 import time
 
+from ovos_bus_client.message import Message
 from ovos_plugin_manager.templates.media import AudioPlayerBackend
 from ovos_utils.log import LOG
 
@@ -15,9 +16,86 @@ class SpotifyOCPAudioService(AudioPlayerBackend):
         super().__init__(config, bus)
         self.spotify = SpotifyClient()
         self._paused = False
-        self.ts = 0
+        self._last_sync_ts = 0
+        self._track_len = 0
+        self._track_pos = 0
         self.device_name = self.config.get("identifier")  # device name in spotify
 
+        self.bus.on("spotifyd.start", self.on_spotify_start)
+        self.bus.on("spotifyd.play", self.on_spotify_play)
+        self.bus.on("spotifyd.pause", self.on_spotify_pause)
+        self.bus.on("spotifyd.stop", self.on_spotify_stop)
+        self.bus.on("spotifyd.load", self.on_spotify_load)
+        self.bus.on("spotifyd.end_of_track", self.on_spotify_end)
+        self.bus.on("spotifyd.change", self.on_spotify_change)
+        self.bus.on("spotifyd.preloading", self.on_spotify_preloading)
+
+    ##################
+    # spotifyd hooks
+    def on_spotify_start(self, message: Message):
+        self._last_sync_ts = time.time()
+        self._now_playing = "spotify:track:" + message.data["track_id"]
+        self._track_pos = message.data["position"]  # milliseconds
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 2}))  # loading media
+
+    def on_spotify_play(self, message: Message):
+        self._last_sync_ts = time.time()
+        self._now_playing = "spotify:track:" + message.data["track_id"]
+        self._track_len = message.data["duration"]  # milliseconds
+        self._track_pos = message.data["position"]  # milliseconds
+
+        self.on_track_start()
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 1}))  # playing
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 6}))  # buffered media
+
+    def on_spotify_stop(self, message: Message):
+        self._now_playing = None
+        self._track_len = 0
+        self._track_pos = 0
+        self._last_sync_ts = 0
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 1}))  # no media
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 0}))  # stopped
+
+    def on_spotify_pause(self, message: Message):
+        self._now_playing = "spotify:track:" + message.data["track_id"]
+        self._track_len = message.data["duration"]  # milliseconds
+        self._track_pos = message.data["position"]  # milliseconds
+        self._last_sync_ts = 0
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 2}))  # paused
+
+    def on_spotify_load(self, message: Message):
+        self._last_sync_ts = time.time()
+        self._track_pos = message.data["position"]  # milliseconds
+        self._now_playing = "spotify:track:" + message.data["track_id"]
+
+    def on_spotify_preloading(self, message: Message):
+        # when track is about to end we get info about next song
+        # we could show a "coming up next" popup
+        pass
+
+    def on_spotify_end(self, message: Message):
+        self._track_pos = self._track_len
+        self.on_track_end()
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 2}))  # paused
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 7}))  # end of media
+
+    def on_spotify_change(self, message: Message):
+        self._now_playing = "spotify:track:" + message.data["track_id"]
+        self._last_sync_ts = time.time()
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 2}))  # paused
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 2}))  # loading media
+
+    #################
     @property
     def device(self):
         for d in self.spotify.devices:
@@ -33,20 +111,20 @@ class SpotifyOCPAudioService(AudioPlayerBackend):
         return ['spotify']
 
     def on_track_start(self):
-        self.ts = time.time()
+        self._last_sync_ts = time.time()
         # Indicate to audio service which track is being played
         if self._track_start_callback:
             self._track_start_callback(self._now_playing)
 
     def on_track_end(self):
         self._paused = False
-        self.ts = 0
+        self._last_sync_ts = 0
         if self._track_start_callback:
             self._track_start_callback(None)
 
     def on_track_error(self):
         self._paused = False
-        self.ts = 0
+        self._last_sync_ts = 0
         self.ocp_error()
 
     def play(self):
@@ -60,7 +138,7 @@ class SpotifyOCPAudioService(AudioPlayerBackend):
 
     def _wait_until_finished(self):
         # pool spotify to see when the player becomes inactive
-        while self.ts > 0:
+        while self._last_sync_ts > 0:
             time.sleep(2)
             for d in self.spotify.devices:
                 if d["name"] == self.device_name and not d["is_active"]:
@@ -98,17 +176,18 @@ class SpotifyOCPAudioService(AudioPlayerBackend):
         """
         getting the duration of the audio in milliseconds
         """
-        # we only can estimate how much we already played as a minimum value
-        return self.get_track_position()
+        return self._track_len or self.get_track_position()
 
     def get_track_position(self) -> int:
         """
         get current position in milliseconds
         """
-        # approximate given timestamp of playback start
-        if self.ts:
-            return int((time.time() - self.ts) * 1000)
-        return 0
+        pos = self._track_pos or 0
+        if self._last_sync_ts:  # add the elapsed time since last update of self._track_pos
+            pos += (time.time() - self._last_sync_ts) * 1000
+        if not self._track_len:
+            self._track_len = pos
+        return min(pos, self._track_len)
 
     def set_track_position(self, milliseconds):
         """

--- a/ovos_media_plugin_spotify/audio.py
+++ b/ovos_media_plugin_spotify/audio.py
@@ -4,6 +4,7 @@ from ovos_plugin_manager.templates.audio import AudioBackend
 from ovos_utils.log import LOG
 
 from ovos_media_plugin_spotify.spotify_client import SpotifyClient
+from ovos_media_plugin_spotify.spotifyd import SpotifydHooks
 
 
 class SpotifyAudioService(AudioBackend):
@@ -15,8 +16,12 @@ class SpotifyAudioService(AudioBackend):
         super().__init__(config, bus, name)
         self.spotify = SpotifyClient()
         self._paused = False
-        self.ts = 0
+        self._last_sync_ts = 0
         self.device_name = self.config.get("identifier")  # device name in spotify
+        self.hooks = SpotifydHooks(bus=self.bus,
+                                   track_start_callback=self.on_track_start,
+                                   track_end_callback=self.on_track_end,
+                                   track_error_callback=self.on_track_error)
 
     @property
     def device(self):
@@ -32,25 +37,31 @@ class SpotifyAudioService(AudioBackend):
             return []
         return ['spotify']
 
-    def on_track_start(self):
-        self.ts = time.time()
+    def on_track_start(self, uri: str = ""):
+        self._now_playing = uri or self._now_playing
+        self._last_sync_ts = time.time()
         # Indicate to audio service which track is being played
         if self._track_start_callback:
             # TODO why is it None sometimes?
             if self._now_playing:
                 self._track_start_callback(self._now_playing)
 
-    def on_track_end(self):
+    def on_track_end(self, uri: str = ""):
+        if not uri:
+            self.hooks.reset_metadata()
         self._paused = False
-        self.ts = 0
+        self._last_sync_ts = 0
         if self._track_start_callback:
             self._track_start_callback(None)
 
-    def on_track_error(self):
+    def on_track_error(self, uri: str = ""):
+        if not uri:
+            self.hooks.reset_metadata()
         self._paused = False
-        self.ts = 0
+        self._last_sync_ts = 0
 
     def play(self, repeat=False):
+        self.hooks.preload_uri(self._now_playing)
         self.on_track_start()
         try:
             self.spotify.play([self._now_playing],
@@ -61,7 +72,7 @@ class SpotifyAudioService(AudioBackend):
 
     def _wait_until_finished(self):
         # pool spotify to see when the player becomes inactive
-        while self.ts > 0:
+        while self._last_sync_ts > 0:
             time.sleep(2)
             for d in self.spotify.devices:
                 if d["name"] == self.device_name and not d["is_active"]:
@@ -106,17 +117,13 @@ class SpotifyAudioService(AudioBackend):
         """
         getting the duration of the audio in milliseconds
         """
-        # we only can estimate how much we already played as a minimum value
-        return self.get_track_position()
+        return self.hooks.get_track_length()
 
     def get_track_position(self) -> int:
         """
         get current position in milliseconds
         """
-        # approximate given timestamp of playback start
-        if self.ts:
-            return int((time.time() - self.ts) * 1000)
-        return 0
+        return self.hooks.get_track_position()
 
     def set_track_position(self, milliseconds):
         """

--- a/ovos_media_plugin_spotify/spotifyd.py
+++ b/ovos_media_plugin_spotify/spotifyd.py
@@ -1,0 +1,122 @@
+import time
+
+from ovos_bus_client.message import Message
+
+
+class SpotifydHooks:
+    def __init__(self, bus,
+                 track_start_callback=None,
+                 track_end_callback=None,
+                 track_error_callback=None):
+        self.current_uri = None
+        self._last_sync_ts = 0
+        self._track_len = 0
+        self._track_pos = 0
+        self.bus = bus
+
+        self.track_start_callback = track_start_callback
+        self.track_end_callback = track_end_callback
+        self.track_error_callback = track_error_callback
+
+        self.bus.on("spotifyd.start", self.on_spotify_start)
+        self.bus.on("spotifyd.play", self.on_spotify_play)
+        self.bus.on("spotifyd.pause", self.on_spotify_pause)
+        self.bus.on("spotifyd.stop", self.on_spotify_stop)
+        self.bus.on("spotifyd.load", self.on_spotify_load)
+        self.bus.on("spotifyd.end_of_track", self.on_spotify_end)
+        self.bus.on("spotifyd.change", self.on_spotify_change)
+        self.bus.on("spotifyd.preloading", self.on_spotify_preloading)
+
+    def reset_metadata(self):
+        self.current_uri = None
+        self._last_sync_ts = 0
+        self._track_len = 0
+        self._track_pos = 0
+
+    def preload_uri(self, uri: str):
+        self.reset_metadata()
+        self.current_uri = uri
+        self._last_sync_ts = time.time()
+
+    def get_track_length(self) -> int:
+        """
+        getting the duration of the audio in milliseconds
+        """
+        return self._track_len or self.get_track_position()
+
+    def get_track_position(self) -> int:
+        """
+        get current position in milliseconds
+        """
+        pos = self._track_pos or 0
+        if self._last_sync_ts:  # add the elapsed time since last update of self._track_pos
+            pos += (time.time() - self._last_sync_ts) * 1000
+        if not self._track_len:
+            self._track_len = pos
+        return min(pos, self._track_len)
+
+    ##################
+    # spotifyd hooks
+    def on_spotify_start(self, message: Message):
+        self._last_sync_ts = time.time()
+        self.current_uri = "spotify:track:" + message.data["track_id"]
+        self._track_pos = message.data["position"]  # milliseconds
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 2}))  # loading media
+
+    def on_spotify_play(self, message: Message):
+        self._last_sync_ts = time.time()
+        self.current_uri = "spotify:track:" + message.data["track_id"]
+        self._track_len = message.data["duration"]  # milliseconds
+        self._track_pos = message.data["position"]  # milliseconds
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 1}))  # playing
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 6}))  # buffered media
+        if self.track_start_callback is not None:
+            self.track_start_callback(self.current_uri)
+
+    def on_spotify_stop(self, message: Message):
+        self.current_uri = None
+        self._track_len = 0
+        self._track_pos = 0
+        self._last_sync_ts = 0
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 1}))  # no media
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 0}))  # stopped
+
+    def on_spotify_pause(self, message: Message):
+        self.current_uri = "spotify:track:" + message.data["track_id"]
+        self._track_len = message.data["duration"]  # milliseconds
+        self._track_pos = message.data["position"]  # milliseconds
+        self._last_sync_ts = 0
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 2}))  # paused
+
+    def on_spotify_load(self, message: Message):
+        self._last_sync_ts = time.time()
+        self._track_pos = message.data["position"]  # milliseconds
+        self.current_uri = "spotify:track:" + message.data["track_id"]
+
+    def on_spotify_preloading(self, message: Message):
+        # when track is about to end we get info about next song
+        # we could show a "coming up next" popup
+        pass
+
+    def on_spotify_end(self, message: Message):
+        self._track_pos = self._track_len
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 2}))  # paused
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 7}))  # end of media
+        if self.track_end_callback is not None:
+            self.track_end_callback(self.current_uri)
+
+    def on_spotify_change(self, message: Message):
+        self.current_uri = "spotify:track:" + message.data["track_id"]
+        self._last_sync_ts = time.time()
+        self.bus.emit(message.forward("ovos.common_play.player.state",
+                                      {"state": 2}))  # paused
+        self.bus.emit(message.forward("ovos.common_play.media.state",
+                                      {"state": 2}))  # loading media

--- a/spotifyd_hooks.py
+++ b/spotifyd_hooks.py
@@ -1,0 +1,103 @@
+"""
+/home/ovos/.local/bin/spotifyd --device-type "speaker" --initial-volume 100 --on-song-change-hook "/home/ovos/.venvs/ovos/bin/python /home/ovos/spotify_events.py" --no-daemon
+"""
+import os
+import time
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.util import get_mycroft_bus
+
+bus = get_mycroft_bus()
+
+spotify_event = os.environ.get("PLAYER_EVENT")
+
+# start
+# {"TRACK_ID": "2MMRakTQnbyuqV7bALPPGw",
+# "PLAYER_EVENT": "start", "PLAY_REQUEST_ID": "0",
+# "POSITION_MS": "218271"}
+if spotify_event == "start":
+    bus.emit(Message("spotifyd.start", {
+        "position": os.environ.get("POSITION_MS", 0),
+        "track_id": os.environ.get("TRACK_ID")}))
+
+# play
+# environment variables {
+# "DURATION_MS": "163066",
+# "PLAYER_EVENT": "play",
+# "PLAY_REQUEST_ID": "0",
+# "TRACK_ID": "3KAS4vmuvRGP2BUQcxmu5i",
+# "POSITION_MS": "25726"}
+if spotify_event == "play":
+    bus.emit(Message("spotifyd.play", {
+        "position": os.environ.get("POSITION_MS", 0),
+        "duration": os.environ.get("DURATION_MS"),
+        "track_id": os.environ.get("TRACK_ID")}))
+
+# pause
+# environment variables {"POSITION_MS": "97601",
+# "PLAYER_EVENT": "pause",
+# "TRACK_ID": "3KAS4vmuvRGP2BUQcxmu5i",
+# "DURATION_MS": "163066",
+# "PLAY_REQUEST_ID": "0"}
+if spotify_event == "pause":
+    bus.emit(Message("spotifyd.pause", {
+        "position": os.environ.get("POSITION_MS", 0),
+        "duration": os.environ.get("DURATION_MS"),
+        "track_id": os.environ.get("TRACK_ID")}))
+
+# next
+# environment variables {"PLAYER_EVENT": "load",
+# "PLAY_REQUEST_ID": "1",
+# "POSITION_MS": "0",
+# "TRACK_ID": "38htK7dMpeSDNtkoKsy1cm"}
+if spotify_event == "load":
+    bus.emit(Message("spotifyd.load", {
+        "position": os.environ.get("POSITION_MS", 0),
+        "track_id": os.environ.get("TRACK_ID")}))
+
+# volume (0-65535)
+# environment variables {
+# "VOLUME": "40166",
+# "PLAYER_EVENT": "volumeset"}
+if spotify_event == "volume":
+    bus.emit(Message("spotifyd.volume",
+                     {"volume": os.environ.get("VOLUME")}))
+
+# when track is about to end we get info about next song
+# can show a "coming up next" popup
+# with environment variables {
+# "PLAYER_EVENT": "preloading",
+# "TRACK_ID": "5Dx8DhETu8DryPg4ap0DDc"}
+if spotify_event == "preloading":
+    bus.emit(Message("spotifyd.preloading",
+                     {"track_id": os.environ.get("TRACK_ID")}))
+
+# end of track
+# {"TRACK_ID": "38htK7dMpeSDNtkoKsy1cm",
+# "PLAYER_EVENT": "endoftrack",
+# "PLAY_REQUEST_ID": "1"}
+if spotify_event == "endoftrack":
+    bus.emit(Message("spotifyd.end_of_track",
+                     {"track_id": os.environ.get("TRACK_ID")}))
+
+# new track start
+# {"PLAYER_EVENT": "change",
+# "OLD_TRACK_ID": "38htK7dMpeSDNtkoKsy1cm",
+# "TRACK_ID": "5Dx8DhETu8DryPg4ap0DDc"}
+if spotify_event == "change":
+    bus.emit(Message("spotifyd.change", {
+        "old_track_id": os.environ.get("OLD_TRACK_ID"),
+        "track_id": os.environ.get("TRACK_ID")}))
+
+# player disconnects from spotify app / playback changes to different device
+# environment variables {
+# "TRACK_ID": "6bckK7uOOyTzzSpGIaJIdT",
+# "PLAY_REQUEST_ID": "17",
+# "PLAYER_EVENT": "stop"}
+if spotify_event == "stop":
+    bus.emit(Message("spotifyd.stop",
+                     {"track_id": os.environ.get("TRACK_ID")}))
+
+time.sleep(1)
+
+bus.close()


### PR DESCRIPTION
adds integration with spotifyd hooks, the hooks script needs to be copied into the ovos device and passed to spotify as an argument

`/home/ovos/.local/bin/spotifyd --device-type "speaker" --initial-volume 100 --on-song-change-hook "/home/ovos/.venvs/ovos/bin/python /home/ovos/spotify_events.py" --no-daemon`


the internal track position calculation logic has also been updated to use these events for extra accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Spotify media plugin with improved event handling for track playback.
	- Introduced `SpotifydHooks` class for better integration and synchronization of track events.
	- Added optional URI parameter to track event methods for flexible metadata handling.
  
- **Bug Fixes**
	- Improved accuracy in tracking playback state and metadata management.

- **Refactor**
	- Streamlined methods for retrieving track length and position, enhancing maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->