### PR TITLE
fix:compat_latest_backend_client

### DIFF
--- a/ovos_media_plugin_spotify/auth.py
+++ b/ovos_media_plugin_spotify/auth.py
@@ -39,7 +39,6 @@ def main():
                            client_secret=CLIENT_SECRET,
                            auth_endpoint="https://accounts.spotify.com/authorize?",
                            token_endpoint="https://accounts.spotify.com/api/token",
-                           refresh_endpoint="https://accounts.spotify.com/api/token",
                            callback_endpoint=f"http://0.0.0.0:{PORT}/auth/callback/{TOKEN_ID}",
                            scope=SCOPE)
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
 spotipy
-ovos-backend-client>=0.1.1,<1.0.0
+ovos-backend-client>=0.2.0,<1.0.0
 ovos-plugin-manager>=0.0.26,<1.0.0


### PR DESCRIPTION
closes https://github.com/OpenVoiceOS/ovos-media-plugin-spotify/issues/17

caused by https://github.com/OpenVoiceOS/ovos-backend-client/pull/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the Spotify authentication process by removing the `refresh_endpoint` parameter, streamlining user authentication.
  
- **Chores**
	- Updated the version constraint for the `ovos-backend-client` dependency to ensure compatibility with new features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->