### PR TITLE
refactor: use the current ovos-config class names

### DIFF
--- a/ovos_media_plugin_spotify/autoconfigure.py
+++ b/ovos_media_plugin_spotify/autoconfigure.py
@@ -1,6 +1,6 @@
 from pprint import pprint
 
-from ovos_config.config import MycroftUserConfig
+from ovos_config.config import UserConfig
 
 from ovos_media_plugin_spotify.spotify_client import SpotifyClient
 
@@ -13,7 +13,7 @@ def main():
         
         If you have not yet authenticated your spotify account, run 'ovos-spotify-oauth' first!
         """)
-    cfg = MycroftUserConfig()
+    cfg = UserConfig()
     spotify = SpotifyClient()
     devices = [d['name'] for d in spotify.devices]
     if not devices:

--- a/ovos_media_plugin_spotify/autoconfigure.py
+++ b/ovos_media_plugin_spotify/autoconfigure.py
@@ -1,6 +1,6 @@
 from pprint import pprint
 
-from ovos_config.config import UserConfig
+from ovos_config.config import MycroftUserConfig
 
 from ovos_media_plugin_spotify.spotify_client import SpotifyClient
 
@@ -13,7 +13,7 @@ def main():
         
         If you have not yet authenticated your spotify account, run 'ovos-spotify-oauth' first!
         """)
-    cfg = UserConfig()
+    cfg = MycroftUserConfig()
     spotify = SpotifyClient()
     devices = [d['name'] for d in spotify.devices]
     if not devices:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 keywords = ["ovos", "audio", "video", "OCP", "plugin"]
 dependencies = [
     "spotipy",
+    "ovos-config>=2.4.0a1,<3.0.0",
     "ovos-plugin-manager>=2.1.0,<3.0.0",
     "ovos-utils>=0.5.0,<1.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 keywords = ["ovos", "audio", "video", "OCP", "plugin"]
 dependencies = [
     "spotipy",
-    "ovos-config>=2.4.0a1,<3.0.0",
+    "ovos-config>=0.0.12,<3.0.0",
     "ovos-plugin-manager>=2.1.0,<3.0.0",
     "ovos-utils>=0.5.0,<1.0.0",
 ]


### PR DESCRIPTION
## Summary
- `MycroftUserConfig` (deprecated alias, see ovos-config#194) -> `UserConfig` in `autoconfigure.py`.
- Added `ovos-config>=2.4.0a1,<3.0.0` as an explicit dependency in `pyproject.toml` (it was imported but never declared).

## Notes
- ovos-config#194 is unreleased. `2.4.0a1` is the expected release version (current dev is `2.3.4a1`, and #194 is a `feat:`). If it ships under a different version, correct the floor pin here.
- **This PR must not merge until ovos-config#194 is merged and released** — the new `UserConfig` name does not exist before that.
- `ovos-plugin-manager>=2.1.0,<3.0.0` and `ovos-utils>=0.5.0,<1.0.0` pins are pre-existing and out of scope for this change.

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` — 2 failed / 2 passed / 2 skipped, identical before and after this change (pre-existing entry-point registration failures unrelated to this rename; shared venv has a pre-#194 ovos-config so import of the new name is expected to be untestable there until #194 ships).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `ovos-config` as a project dependency to support configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->